### PR TITLE
Modular Turrets compat

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,0 +1,3 @@
+if mods["scattergun_turret"] then	
+	require("prototypes.entity.updated.modularturret")
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -6,3 +6,6 @@ require("prototypes.technology.updated.technology")
 if mods["Krastorio2"] then	
 	require("prototypes.item.updated.krastorio-gun")
 end
+if mods["scattergun_turret"] then	
+	require("prototypes.entity.updated.modularturret")
+end

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -6,6 +6,3 @@ require("prototypes.technology.updated.technology")
 if mods["Krastorio2"] then	
 	require("prototypes.item.updated.krastorio-gun")
 end
-if mods["scattergun_turret"] then	
-	require("prototypes.entity.updated.modularturret")
-end

--- a/info.json
+++ b/info.json
@@ -8,6 +8,7 @@
 	"factorio_version": "0.18",
 	"dependencies":[
 		"base >= 0.18",
-		"? Krastorio2 >= 0.9.6"
+		"? Krastorio2 >= 0.9.6",
+		"? scattergun_turret >= 5.1.0"
 	]
 }

--- a/prototypes/entity/updated/modularturret.lua
+++ b/prototypes/entity/updated/modularturret.lua
@@ -1,0 +1,5 @@
+-- Update the entity gun-turret
+data.raw["ammo-turret"]["w93-gatling-turret"].attack_parameters.ammo_category = "turret-bullet"
+data.raw["ammo-turret"]["w93-gatling-turret2"].attack_parameters.ammo_category = "turret-bullet"
+data.raw["ammo-turret"]["w93-hmg-turret"].attack_parameters.ammo_category = "turret-bullet"
+data.raw["ammo-turret"]["w93-hmg-turret2"].attack_parameters.ammo_category = "turret-bullet"


### PR DESCRIPTION
Adds EVE Weaponry ammo override to Modular Turret's Gatling and Heavy Machine Gun turrets, both frontline and backline. Pretty much the only gun turrets in Modular Turrets. Also overrides Modular Turret's integration with Krastorio 2, though I assume if you're using them together, you probably want this anyway.